### PR TITLE
Исправление в разделе Метод индекса совпадений.

### DIFF
--- a/coincide-index_method.tex
+++ b/coincide-index_method.tex
@@ -90,14 +90,14 @@
 \[
     I(\mathcal{P}_1, \mathcal{P}_2, \ldots, \mathcal{P}_m ) ~=
 \] \[
-    =~ \frac{2}{L(L - 1)} \left( \frac{1}{2} \frac{L}{m} \left( \frac{L}{m} - 1 \right) k_{p_1} ~+~
+    =~ \frac{2}{L(L - 1)} \left\{ \frac{1}{2} \frac{L}{m} \left( \frac{L}{m} - 1 \right) k_{p_1} ~+~
         \frac{1}{2} \frac{L}{m} \left( \frac{L}{m} - 1 \right) k_{p_2} ~+ \right.
 \] \[
-        +~ \dots ~+~ \left. \frac{1}{2} \frac{L}{m} \left( \frac{L}{m} - 1 \right) k_{p_m} \right) ~+
+        +~ \dots ~+~ \left. \frac{1}{2} \frac{L}{m} \left( \frac{L}{m} - 1 \right) k_{p_m} \right\} ~+
 \] \[
-       +~ \frac{2}{L(L - 1)} \left( \left( \frac{L}{m} \right)^2 k_{p_1, p_2} +
+       +~ \frac{2}{L(L - 1)} \left\{ \left( \frac{L}{m} \right)^2 k_{p_1, p_2} +
          \left( \frac{L}{m} \right)^2 k_{p_1, p_3} + \dots +
-        \left( \frac{L}{m} \right)^2 k_{p_{m - 1}, p_m } \right).
+        \left( \frac{L}{m} \right)^2 k_{p_{m - 1}, p_m } \right\}.
 \] }
 Первая фигурная скобка содержит  $m$ слагаемых, вторая -- $ \frac{m(m-1)}{2}$ слагаемых. Полагая
     \[ k_{p_1} = k_{p_2} = \dots = k_{p_m} = k_p, \]


### PR DESCRIPTION
Испарвлено ( на {, } на ). Так как строчкой ниже написано про две суммы в фигурных скобках, а не в обычных.
