### PR TITLE
Стиль написания формулы условной энтропии

### DIFF
--- a/perfect_secure_systems.tex
+++ b/perfect_secure_systems.tex
@@ -52,7 +52,7 @@
 \[ I(M; C) = H(M) - H(M | C). \]
 Очевидны следующие соотношения условных и безусловных энтропий~\cite{GabPil:2007}:
 \[H(K|C)=H(K|C)+H(M|K,C)=H(M,K|C),\]
-\[H(M,K|C)=H(M|C)+H(K|M,C)\geq H(M|C),\]
+\[H(MK|C)=H(M|C)+H(K|MC)\geq H(M|C),\]
 \[H(K)\geq H(K|C)\geq H(M|C).\]
 Отсюда получаем:
  \[ I(M; C) = H(M) - H(M | C)\geq H(M)-H(K). \]


### PR DESCRIPTION
Начиная с главы "расстояние единственности" запятая отсутствует, до этого она присутствует. Лучше писать всё одним стилем, т.к. разное написание может вызвать у неподготовленного читателя лишние вопросы.