### PR TITLE
Change dots in matrix shamirs_secret_sharing.tex

### DIFF
--- a/shamirs_secret_sharing.tex
+++ b/shamirs_secret_sharing.tex
@@ -7,16 +7,11 @@
 Рассмотрим матрицу Вандермонда $V$ размера $(n \times n)$, где
 \[
     V = \left(\begin{array}{cccc}
-        {1} & {1} & { \ldots } & {1} \\
-        {x_{1} } & {x_{2} } & { \ldots } & {x_{n} } \\
-        {\begin{array}{l} {} \\ {x_{1}^{2} } \end{array}} &
-            {\begin{array}{l} {} \\ {x_{2}^{2} } \end{array}} &
-            {\begin{array}{l} {} \\ { \ldots } \end{array}} &
-            {\begin{array}{l} {} \\ {x_{n}^{2} } \end{array}} \\
-        {\begin{array}{l} { \ldots } \\ {x_{1}^{n-1} } \end{array}} &
-            {\begin{array}{l} { \ldots } \\ {x_{2}^{n-1} } \end{array}} &
-            {\begin{array}{l} { \ldots } \\ { \ldots } \end{array}} &
-            {\begin{array}{l} { \ldots } \\ {x_{n}^{n-1} } \end{array}}
+        {1} & {1} & { \cdots } & {1} \\
+        { x_{1} } & { x_{2} } & { \cdots } & { x_{n} } \\
+        { x_{1}^{2} } & { x_{2}^{2} } & { \cdots } & { x_{n}^{2}} \\
+        { \vdots } & { \vdots } & { \ddots } & { \vdots } \\
+        { x_{1}^{n-1} } & { x_{2}^{n-1} } & { \cdots } & { x_{n}^{n-1} }
     \end{array}\right),
 \]
 где $x_{i}$ -- элемент поля $\Z_{p}$, $x_{i} \ne x_{j}$, $p$ -- большое простое\index{число!простое} число.
@@ -84,10 +79,10 @@
     \item Строит прямоугольную матрицу Вандермонда:
         \[
             V_{n \times N} = \left( \begin{array}{cccc}
-                {1} & {1} & { \ldots } & {1} \\
-                {x_{1} } & {x_{2} } & { \ldots } & {x_{N} } \\
-                { \ldots } & { \ldots } & { \ldots } & { \ldots } \\
-                {x_{1}^{n-1} } & {x_{2}^{n-1} } & { \ldots } & {x_{N}^{n-1} }
+                {1} & {1} & { \cdots } & {1} \\
+                {x_{1} } & {x_{2} } & { \cdots } & {x_{N} } \\
+                { \vdots } & { \vdots } & { \ddots } & { \vdots } \\
+                {x_{1}^{n-1} } & {x_{2}^{n-1} } & { \cdots } & {x_{N}^{n-1} }
             \end{array} \right) \mod p.
         \]
     \item Выбирает секрет $K_0$, а также выбирает случайные числа $K_1, K_2, \dots, K_{n-1}$.


### PR DESCRIPTION
В столбцах должны быть `\vdots`, на диагоналях — `\ddots`, в строках — `\cdots`.

Либо если это не подходит, можно использовать для пропуска строки — `\hdotsfor{number}`
Source: ftp://ftp.ams.org/pub/tex/doc/amsmath/amsldoc.pdf