### PR TITLE
Update coincide-index_method.tex

### DIFF
--- a/coincide-index_method.tex
+++ b/coincide-index_method.tex
@@ -74,7 +74,7 @@
 {\mathbf X} = \left[ {\begin{array}{*{20}c}
    {X_1 } & {X_2 } &  \ldots  & {X_{L/m} }  \\
    {Y_1 } & {Y_2 } &  \ldots  & {Y_{L/m} }  \\
-    \vdots  &  \vdots  &  \vdots  &  \vdots   \\
+    \vdots  &  \vdots  &  \ddots  &  \vdots   \\
    {Z_1 } & {Z_2 } &  \ldots  & {Z_{L/m} }  \\
 \end{array}} \right].
 \]


### PR DESCRIPTION
Better to use diagonal dots in matrix for denoting skipped part
