### PR TITLE
Update bibliography.bib: Added Selberg`s name

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -92,7 +92,7 @@
 }
 
 @article{Selberg:1949,
-	author		= {Selberg, A.},
+	author		= {Selberg, Atle},
 	title		= {An Elementary Proof of the Prime-Number Theorem},
 	journal		= {Annals of Mathematics},
 	volume		= {50},


### PR DESCRIPTION
Пруф - статья о нем на вики (https://en.wikipedia.org/wiki/Atle_Selberg), где в сносках его публикация "An Elementary Proof of the Prime-Number Theorem"