### PR TITLE
Update Short_history_of_cryptography.tex

### DIFF
--- a/Short_history_of_cryptography.tex
+++ b/Short_history_of_cryptography.tex
@@ -8,7 +8,7 @@
 	\centering
 	\subfloat[Скитала. Рисунок современного автора. Рисунок участника Wikimedia Commons Luringen, доступно по \href{https://creativecommons.org/licenses/by-sa/3.0/deed.ru}{лицензии CC-BY-SA 3.0}]{\label{fig:Skytale}\includegraphics[width=0.60\textwidth]{pic/Skytale}}
 	~~~~
-	\subfloat[Аристотель (384 -- 322~гг.~до~н.~э.). Римская копия оригинала Лисиппа]{\includegraphics[width=0.35\textwidth]{pic/Aristotle_Altemps_Inv8575}}
+	\subfloat[Аристотель (384--322~гг.~до~н.~э.). Римская копия оригинала Лисиппа]{\includegraphics[width=0.35\textwidth]{pic/Aristotle_Altemps_Inv8575}}
 	\caption{Скитала\index{скитала}, <<шифр Древней Спарты>>\index{шифр!Древней Спарты}}
 \end{figure}
 


### PR DESCRIPTION
Согласно http://new.gramota.ru/spravka/letters/22-spravka/letters/90-data между датами ставится тире без пробелов.
Юсупов Р., 211