### PR TITLE
foreword.tex: leftmargin need length argument, so drop it

### DIFF
--- a/foreword.tex
+++ b/foreword.tex
@@ -11,7 +11,7 @@
 
 \begin{multicols}{2}
 \begin{small}
-\begin{itemize}[leftmargin=*]\itemsep1pt \parskip0pt \parsep0pt
+\begin{itemize}\itemsep 1pt \parskip 0pt \parsep 0pt
 	\item[] Татьяна Бакланова\begin{tiny} (201-211 гр.)\end{tiny}
 	\item[] Дмитрий Банков\begin{tiny} (201-011 гр.)\end{tiny}
 	\item[] Даниил Бершацкий\begin{tiny} (201-012 гр.)\end{tiny}


### PR DESCRIPTION
leftmargin usage:
	\begin{itemize}[leftmargin=-.5in]

Signed-off-by: Sergey Koshechkin <serge.koshechkin@gmail.com>