### PR TITLE
65 Update unicity_distance.tex

### DIFF
--- a/unicity_distance.tex
+++ b/unicity_distance.tex
@@ -74,9 +74,10 @@ n_u \approx \frac{l_K}{\rho}.
 	\[ \rho _{ru} \approx 1 - \frac{ 3{,}0 }{ \log _2 {32} } \approx 0{,}40.\]
 
 Однако если предположить, что текст передаётся в формате простого текстового файла (\langen{plain text}) в стандартной кодировке UTF-8 (один байт на английский символ и два -- на кириллицу), то значения избыточности становятся примерно равны $0{,}83$ для английского и $0{,}81$ для русского языков:
-
-	\[ \rho _{en, UTF-8} \approx 1 - \frac{ 1{,}3 }{ \log _2 {2^{8}} } \approx 0{,}83,\]
-	\[ \rho _{ru, UTF-8} \approx 1 - \frac{ 3{,}0 }{ \log _2 {2^{16}} } \approx 0{,}81.\]
+\begin{gather*}
+\rho _{en, \text{\textit{UTF-8}}} \approx 1 - \frac{ 1{,}3 }{ \log _2 {2^{8}} } \approx 0{,}83,\\
+\rho _{ru, \text{\textit{UTF-8}}} \approx 1 - \frac{ 3{,}0 }{ \log _2 {2^{16}} } \approx 0{,}81.
+\end{gather*} 
 
 Подставляя полученные числа в выражение~\ref{eq:unicity_distance_simple_frac} для шифров DES\index{шифр!DES} и AES\index{шифр!AES}, получаем таблицу~\ref{table:unicity_distances}.
 


### PR DESCRIPTION
неаккуратный матмод испортил дефис в аббревиатуре UTF-8. А именно сделал ее минусом. Так не должно быть!