### PR TITLE
Update perfect_secure_systems.tex

### DIFF
--- a/perfect_secure_systems.tex
+++ b/perfect_secure_systems.tex
@@ -54,7 +54,7 @@
 \[ I(M; C) = H(M) - H(M | C). \]
 Очевидны следующие соотношения условных и безусловных энтропий~\cite{GabPil:2007}:
 \begin{gather*}
-H(K|C)=H(K|C)+H(M|K,C)=H(M,K|C),\\
+H(K|C)=H(K|C)+H(M|KC)=H(MK|C),\\
 H(MK|C)=H(M|C)+H(K|MC)\geq H(M|C),\\
 H(K)\geq H(K|C)\geq H(M|C).
 \end{gather*}


### PR DESCRIPTION
Подобные выражения используются без запятой в тексте книги. К тому же 
<img width="361" alt="_ _2016-12-20_ _18_27_15" src="https://cloud.githubusercontent.com/assets/19874635/21356281/1b86ca98-c6e2-11e6-80ff-e550c9df391d.png">
