### PR TITLE
Update MAC.tex

### DIFF
--- a/MAC.tex
+++ b/MAC.tex
@@ -67,5 +67,5 @@ $\textrm{ipad}$ -- последовательность повторяющихс
 \[
     \MAC(K, m \| m_{n+1}) = \underbrace{H \left( K \| m_1 \| m_2 \| \dots \| m_n \right.}_{\MAC(K, m)} \left. \| m_{n+1} \right) =
 \] \[
-    f(\MAC(K, m), m_{n+1}).
+     = f(\MAC(K, m), m_{n+1}).
 \]


### PR DESCRIPTION
знак равенства дублируется при переносе на следующую строку