### PR TITLE
Improved stack_overflow.tex

### DIFF
--- a/stack_overflow.tex
+++ b/stack_overflow.tex
@@ -126,8 +126,7 @@ int main() {
     "\x50\xEB\xFF\xFF"                  // регистр
     "\xFF\x7F\x00\x00"                  //   rbp=0x7fffffffeb50
     "\xC0\xEA\xFF\xFF"                  // регистр
-    "\xFF\x7F\x00\x00"                  //   rip=0x7fffffffeac0
-    ;
+    "\xFF\x7F\x00\x00";                 //   rip=0x7fffffffeac0
   ...
   return hamming_distance(b1, b2, text, 68);
   ...


### PR DESCRIPTION
Раньше при сборке последняя фигурная скобка вылезала после следующей далее таблицы, теперь таблица отрисовывается прямо за блоком кода.