### PR TITLE
Update Short_history_of_cryptography.tex

### DIFF
--- a/Short_history_of_cryptography.tex
+++ b/Short_history_of_cryptography.tex
@@ -6,7 +6,7 @@
 
 \begin{figure}[t]
 	\centering
-	\subcaptionbox{Скитала. Рисунок современного автора. Рисунок участника Wikimedia Commons Luringen, доступно по \href{https://creativecommons.org/licenses/by-sa/3.0/deed.ru}{лицензии CC-BY-SA 3.0}\label{fig:Skytale}}{\includegraphics[width=0.60\textwidth]{pic/Skytale}}
+	\subcaptionbox{Скитала. Рисунок современного автора. Рисунок участника Wikimedia Commons Luringen, доступно по \href{https://creativecommons.org/licenses/by-sa/3.0/deed.ru}{лицензии CC BY-SA 3.0}\label{fig:Skytale}}{\includegraphics[width=0.60\textwidth]{pic/Skytale}}
 	~~
 	\subcaptionbox{Аристотель (384 -- 322~гг.~до~н.~э.). Римская копия оригинала Лисиппа}{\includegraphics[width=0.35\textwidth]{pic/Aristotle_Altemps_Inv8575}}
 	\caption{Скитала\index{скитала}, <<шифр Древней Спарты>>\index{шифр!Древней Спарты}}


### PR DESCRIPTION
При просмотре этой картинки https://ru.wikipedia.org/wiki/%D0%A1%D0%BA%D0%B8%D1%82%D0%B0%D0%BB%D0%B0#/media/File:Skytale.png и на сайте лицензии https://creativecommons.org/licenses/by-sa/3.0/deed.en лицензия оформлена 
в виде "CC BY-SA 3.0".
Предлагаю заменить "CC-BY-SA 3.0" на "CC BY-SA 3.0".