### PR TITLE
Update diffie-hellman.tex

### DIFF
--- a/diffie-hellman.tex
+++ b/diffie-hellman.tex
@@ -42,8 +42,8 @@
     \item На завершающем третьем этапе стороны вычисляют:
         \begin{enumerate}
             \item $A: ~ K_A = (g^{yz})^x = g^{xyz} \mod p$.
-            \item $B: ~ K_A = (g^{zx})^y = g^{xyz} \mod p$.
-            \item $C: ~ K_A = (g^{xy})^z = g^{xyz} \mod p$.
+            \item $B: ~ K_B = (g^{zx})^y = g^{xyz} \mod p$.
+            \item $C: ~ K_C = (g^{xy})^z = g^{xyz} \mod p$.
         \end{enumerate}
 \end{enumerate}
 


### PR DESCRIPTION
две замены:
K_A -> K_B 
K_A -> K_C
Из описания выше по тексту следует, что B и С вычисляют собственные сеансовые ключи, которые совпадают и совпадают с K_A. А здесь получается, что они K_A вычисляют (на самом деле ключи равные K_A), а дальше упомянуты K_B и K_C, которые никак не вычисляются. Поэтому следует исправить.