### PR TITLE
pki_key_length.tex: Добавлено пояснение.

### DIFF
--- a/pki_key_length.tex
+++ b/pki_key_length.tex
@@ -59,7 +59,7 @@
 \begin{enumerate}
     \item RSA\index{электронная подпись!RSA}:
         \[ (2 \log_2 n) \cdot \left( \frac{\log_2 n}{t} \right)^2; \]
-    \item DSA\index{электронная подпись!DSA} (\langen{Digital Signature Algorithm}, стандарт США~\cite{FIPS-PUB-186-4}), вычисляемая по принципу Эль-Гамаля\index{криптосистема!Эль-Гамаля} по модулю $p$ и с порядком циклической подгруппы $q$:
+    \item DSA\index{электронная подпись!DSA} (\langen{Digital Signature Algorithm}, стандарт США~\cite{FIPS-PUB-186-4}) -- электронная подпись, вычисляемая по принципу Эль-Гамаля\index{криптосистема!Эль-Гамаля} по модулю $p$ и с порядком циклической подгруппы $q$:
         \[ (2 \log_2 q) \cdot \left( \frac{\log_2 p}{t} \right)^2; \]
     \item ГОСТ Р 34.10-2001\index{электронная подпись!ГОСТ Р 34.10-2001} (стандарт России~\cite{GOST-2001}) и ECDSA\index{электронная подпись!ECDSA} (\langen{Elliptic Curve Digital Signature Algorithm}, стандарт США~\cite{FIPS-PUB-186-4}), вычисляемые по принципу Эль-Гамаля\index{криптосистема!Эль-Гамаля} в группе точек эллиптической кривой по модулю $p$:
         \[ (2 \log_2 p) \cdot 4 \cdot \left( \frac{\log_2 p}{t} \right)^2. \]


### PR DESCRIPTION
Добавлено: "DSA **- электронная подпись**, вычисляемая ..."
Считаю это исправление нужным, поскольку в отсутствие приложения фраза читается как "DSA, вычисляемая...", что приводит к несогласованию родов причастия и аббревиатуры, поскольку **DSA - алгоритм**, м.р., в то время как **вычисляемая** - ж.р.