### PR TITLE
Update key_distribution-kerberos.tex - пропущена 'н' в "довереного це…

### DIFF
--- a/key_distribution-kerberos.tex
+++ b/key_distribution-kerberos.tex
@@ -8,7 +8,7 @@
 \begin{figure}[!htb]
     \centering
     \includegraphics[width=0.5\textwidth]{pic/key_distribution-kerberos}
-    \caption{Схема взаимодействия абонентов и довереного центра в протоколе <<Kerberos>>\label{fig:key_distribution-kerberos}}
+    \caption{Схема взаимодействия абонентов и доверенного центра в протоколе <<Kerberos>>\label{fig:key_distribution-kerberos}}
 \end{figure}
 
 \begin{enumerate}


### PR DESCRIPTION
…нтра"

Доверенный центр, пишется с двумя 'н'.