### PR TITLE
Снято дублирование установочного пакета

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ $ sudo apt-get install texlive-lang-german \
     texlive-lang-french \
     texlive-lang-european \
     texlive-lang-cyrillic
-$ sudo apt-get install texlive-lang-french
 ```
 
 #### OS X:


### PR DESCRIPTION
В шаблоне комманд для установки необходимых компонентов для Linux пакет `texlive-lang-french` избыточным образом фигурирует дважды.